### PR TITLE
remove unnecessary crypto package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,5 @@
     "url": "https://github.com/eswak/swift-temp-url/issues"
   },
   "homepage": "https://github.com/eswak/swift-temp-url",
-  "dependencies": {
-    "crypto": "0.0.3"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
See https://medium.com/@rmehlinger/crypto-collision-f41c206de27b. This package has no license and no tests, and masks a built in NodeJS library. Thankfully, Node does not allow its crypto package to be overwritten by this thing, so requiring it doesn't actually do anything.